### PR TITLE
Add support for Embedded component - Iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ liElements := elem.TransformEach(items, func(item string) elem.Node {
 
 ulElement := elem.Ul(nil, liElements)
 ```
+
 In this example, we transformed a slice of strings into a list of `li` elements and then wrapped them in a `ul` element.
 
 ### Conditional Rendering with `If`
@@ -125,7 +126,8 @@ In this example, if `isAdmin` is `true`, the `Admin Panel` link is rendered. Oth
 - **Interactive Elements**: `Dialog`, `Menu`
 - **Grouping Content**: `Div`, `Span`, `Li`, `Ul`, `Ol`, `Dl`, `Dt`, `Dd`
 - **Tables**: `Table`, `Tr`, `Td`, `Th`, `TBody`, `THead`, `TFoot`
-- **Embedded Content**: `Img`
+- **Hyperlinks and Multimedia**: `Img`
+- **Embedded Content**: `Iframe`
 - **Script-supporting Elements**: `Script`, `Noscript`
 - **Inline Semantic**: `A`, `Strong`, `Em`, `Code`, `I`
 

--- a/attrs/attrs.go
+++ b/attrs/attrs.go
@@ -11,7 +11,7 @@ const (
 	Style           = "style"
 	Tabindex        = "tabindex"
 	Title           = "title"
-	Loading			= "loading"
+	Loading         = "loading"
 
 	// Link/Script Attributes
 	Async       = "async"
@@ -83,12 +83,12 @@ const (
 	Headers = "headers"
 
 	// IFrame Attributes
-	Allow = "allow"
+	Allow           = "allow"
 	AllowFullScreen = "allowfullscreen"
-	CSP = "csp"
-	ReferrerPolicy = "referrerpolicy"
-	Sandbox = "sandbox"
-	SrcDoc = "srcdoc"
+	CSP             = "csp"
+	ReferrerPolicy  = "referrerpolicy"
+	Sandbox         = "sandbox"
+	SrcDoc          = "srcdoc"
 )
 
 type Props map[string]string

--- a/attrs/attrs.go
+++ b/attrs/attrs.go
@@ -11,6 +11,7 @@ const (
 	Style           = "style"
 	Tabindex        = "tabindex"
 	Title           = "title"
+	Loading			= "loading"
 
 	// Link/Script Attributes
 	Async       = "async"
@@ -80,6 +81,14 @@ const (
 	ColSpan = "colspan"
 	Scope   = "scope"
 	Headers = "headers"
+
+	// IFrame Attributes
+	Allow = "allow"
+	AllowFullScreen = "allowfullscreen"
+	CSP = "csp"
+	ReferrerPolicy = "referrerpolicy"
+	Sandbox = "sandbox"
+	SrcDoc = "srcdoc"
 )
 
 type Props map[string]string

--- a/elem.go
+++ b/elem.go
@@ -33,18 +33,19 @@ var voidElements = map[string]struct{}{
 // attribute represents the "true" value. To represent the "false" value, the attribute has to be omitted.
 // See https://html.spec.whatwg.org/multipage/indices.html#attributes-3 for reference
 var booleanAttrs = map[string]struct{}{
-	attrs.Async:      {},
-	attrs.Autofocus:  {},
-	attrs.Checked:    {},
-	attrs.Defer:      {},
-	attrs.Disabled:   {},
-	attrs.IsMap:      {},
-	attrs.Multiple:   {},
-	attrs.NoValidate: {},
-	attrs.Open:       {},
-	attrs.Readonly:   {},
-	attrs.Required:   {},
-	attrs.Selected:   {},
+	attrs.Async:           {},
+	attrs.Autofocus:       {},
+	attrs.Checked:         {},
+	attrs.Defer:           {},
+	attrs.Disabled:        {},
+	attrs.IsMap:           {},
+	attrs.Multiple:        {},
+	attrs.NoValidate:      {},
+	attrs.Open:            {},
+	attrs.Readonly:        {},
+	attrs.Required:        {},
+	attrs.Selected:        {},
+	attrs.AllowFullScreen: {},
 }
 
 type Node interface {

--- a/elements.go
+++ b/elements.go
@@ -302,9 +302,8 @@ func Td(attrs attrs.Props, children ...Node) *Element {
 	return NewElement("td", attrs, children...)
 }
 
-
 // ========== Embedded Content ==========
 
-func Iframe(attrs attrs.Props, children ...Node) *Element{
+func IFrame(attrs attrs.Props, children ...Node) *Element {
 	return NewElement("iframe", attrs, children...)
 }

--- a/elements.go
+++ b/elements.go
@@ -301,3 +301,10 @@ func Th(attrs attrs.Props, children ...Node) *Element {
 func Td(attrs attrs.Props, children ...Node) *Element {
 	return NewElement("td", attrs, children...)
 }
+
+
+// ========== Embedded Content ==========
+
+func Iframe(attrs attrs.Props, children ...Node) *Element{
+	return NewElement("iframe", attrs, children...)
+}

--- a/elements_test.go
+++ b/elements_test.go
@@ -1,8 +1,9 @@
 package elem
 
 import (
-	"github.com/chasefleming/elem-go/styles"
 	"testing"
+
+	"github.com/chasefleming/elem-go/styles"
 
 	"github.com/chasefleming/elem-go/attrs"
 	"github.com/stretchr/testify/assert"
@@ -456,5 +457,18 @@ func TestTFoot(t *testing.T) {
 func TestTable(t *testing.T) {
 	expected := `<table><tr><th>Table header</th></tr><tr><td>Table content</td></tr></table>`
 	el := Table(nil, Tr(nil, Th(nil, Text("Table header"))), Tr(nil, Td(nil, Text("Table content"))))
+	assert.Equal(t, expected, el.Render())
+}
+
+// ========== Embedded Content ==========
+func TestEmbedLink(t *testing.T) {
+	expected := `<iframe src="https://www.youtube.com/embed/446E-r0rXHI?si=ji7WiR0cuDVSTWJ2"></iframe>`
+	el := IFrame(attrs.Props{attrs.Src: "https://www.youtube.com/embed/446E-r0rXHI?si=ji7WiR0cuDVSTWJ2"})
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestAllowFullScreen(t *testing.T) {
+	expected := `<iframe allowfullscreen src="https://www.youtube.com/embed/446E-r0rXHI?si=ji7WiR0cuDVSTWJ2"></iframe>`
+	el := IFrame(attrs.Props{attrs.Src: "https://www.youtube.com/embed/446E-r0rXHI?si=ji7WiR0cuDVSTWJ2", attrs.AllowFullScreen: "true"})
 	assert.Equal(t, expected, el.Render())
 }


### PR DESCRIPTION
Closes Issue #45 
- Updated Readme.md
- Added support in elements.go
```go
// ========== Embedded Content ==========

func Iframe(attrs attrs.Props, children ...Node) *Element{
	return NewElement("iframe", attrs, children...)
}
```
- Updated attrs
```go
// IFrame Attributes
	Allow = "allow"
	AllowFullScreen = "allowfullscreen"
	CSP = "csp"
	ReferrerPolicy = "referrerpolicy"
	Sandbox = "sandbox"
	SrcDoc = "srcdoc"
```