### PR TITLE
Add doctype preamble to html tag

### DIFF
--- a/elem.go
+++ b/elem.go
@@ -112,6 +112,13 @@ type Element struct {
 }
 
 func (e *Element) RenderTo(builder *strings.Builder) {
+	// The HTML tag needs a doctype preamble in order to ensure
+	// browsers don't render in legacy/quirks mode
+	// https://developer.mozilla.org/en-US/docs/Glossary/Doctype
+	if e.Tag == "html" {
+		builder.WriteString("<!DOCTYPE html>")
+	}
+
 	// Start with opening tag
 	builder.WriteString("<")
 	builder.WriteString(e.Tag)

--- a/elements_test.go
+++ b/elements_test.go
@@ -18,7 +18,7 @@ func TestBody(t *testing.T) {
 }
 
 func TestHtml(t *testing.T) {
-	expected := `<html lang="en"><head><meta charset="UTF-8"><title>Elem Page</title></head><body><p>Welcome to Elem!</p></body></html>`
+	expected := `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Elem Page</title></head><body><p>Welcome to Elem!</p></body></html>`
 	el := Html(attrs.Props{attrs.Lang: "en"},
 		Head(nil,
 			Meta(attrs.Props{attrs.Charset: "UTF-8"}),


### PR DESCRIPTION
The doctype preamble needs to be emmitted in order to ensure browsers don't switch to legacy/quirks mode rendering.

Fixes: #91