### PR TITLE
make syntax less verbose

### DIFF
--- a/attrs/attrs.go
+++ b/attrs/attrs.go
@@ -1,5 +1,12 @@
 package attrs
 
+import (
+	"sort"
+	"strings"
+
+	"github.com/chasefleming/elem-go/options"
+)
+
 const (
 	// Universal Attributes
 
@@ -181,4 +188,70 @@ const (
 	AriaValuetext        = "aria-valuetext"
 )
 
+// List of boolean attributes. Boolean attributes can't have literal values. The presence of an boolean
+// attribute represents the "true" value. To represent the "false" value, the attribute has to be omitted.
+// See https://html.spec.whatwg.org/multipage/indices.html#attributes-3 for reference
+var booleanAttrs = map[string]struct{}{
+	AllowFullscreen: {},
+	Async:           {},
+	Autofocus:       {},
+	Autoplay:        {},
+	Checked:         {},
+	Controls:        {},
+	Defer:           {},
+	Disabled:        {},
+	Ismap:           {},
+	Loop:            {},
+	Multiple:        {},
+	Muted:           {},
+	Novalidate:      {},
+	Open:            {},
+	Playsinline:     {},
+	Readonly:        {},
+	Required:        {},
+	Selected:        {},
+}
+
 type Props map[string]string
+
+func (p Props) RenderTo(builder *strings.Builder, opts options.RenderOptions) {
+	// Sort the keys for consistent order
+	keys := make([]string, 0, len(p))
+	for k := range p {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Append the attributes to the builder
+	for _, k := range keys {
+		p.renderAttrTo(k, builder)
+	}
+}
+
+// return string representation of given attribute with its value
+func (p Props) renderAttrTo(attrName string, builder *strings.Builder) {
+	if _, exists := booleanAttrs[attrName]; exists {
+		// boolean attribute presents its name only if the value is "true"
+		if p[attrName] == "true" {
+			builder.WriteString(` `)
+			builder.WriteString(attrName)
+		}
+	} else {
+		// regular attribute has a name and a value
+		builder.WriteString(` `)
+		builder.WriteString(attrName)
+		builder.WriteString(`="`)
+		builder.WriteString(p[attrName])
+		builder.WriteString(`"`)
+	}
+}
+
+func (p Props) Render() string {
+	return p.RenderWithOptions(options.RenderOptions{})
+}
+
+func (p Props) RenderWithOptions(opts options.RenderOptions) string {
+	var builder strings.Builder
+	p.RenderTo(&builder, opts)
+	return builder.String()
+}

--- a/elements.go
+++ b/elements.go
@@ -7,30 +7,30 @@ import (
 // ========== Document Structure ==========
 
 // Body creates a <body> element.
-func Body(attrs attrs.Props, children ...Node) *Element {
-	return newElement("body", attrs, children...)
+func Body(children ...Node) *Element {
+	return newElement("body", children...)
 }
 
 // Head creates a <head> element.
-func Head(attrs attrs.Props, children ...Node) *Element {
-	return newElement("head", attrs, children...)
+func Head(children ...Node) *Element {
+	return newElement("head", children...)
 }
 
 // Html creates an <html> element.
-func Html(attrs attrs.Props, children ...Node) *Element {
-	return newElement("html", attrs, children...)
+func Html(children ...Node) *Element {
+	return newElement("html", children...)
 }
 
 // Title creates a <title> element.
-func Title(attrs attrs.Props, children ...Node) *Element {
-	return newElement("title", attrs, children...)
+func Title(children ...Node) *Element {
+	return newElement("title", children...)
 }
 
 // ========== Text Formatting and Structure ==========
 
 // A creates an <a> element.
-func A(attrs attrs.Props, children ...Node) *Element {
-	return newElement("a", attrs, children...)
+func A(children ...Node) *Element {
+	return newElement("a", children...)
 }
 
 // Br creates a <br> element.
@@ -39,58 +39,58 @@ func Br(attrs attrs.Props) *Element {
 }
 
 // Blockquote creates a <blockquote> element.
-func Blockquote(attrs attrs.Props, children ...Node) *Element {
-	return newElement("blockquote", attrs, children...)
+func Blockquote(children ...Node) *Element {
+	return newElement("blockquote", children...)
 }
 
 // Code creates a <code> element.
-func Code(attrs attrs.Props, children ...Node) *Element {
-	return newElement("code", attrs, children...)
+func Code(children ...Node) *Element {
+	return newElement("code", children...)
 }
 
 // Div creates a <div> element.
-func Div(attrs attrs.Props, children ...Node) *Element {
-	return newElement("div", attrs, children...)
+func Div(children ...Node) *Element {
+	return newElement("div", children...)
 }
 
 // Em creates an <em> element.
-func Em(attrs attrs.Props, children ...Node) *Element {
-	return newElement("em", attrs, children...)
+func Em(children ...Node) *Element {
+	return newElement("em", children...)
 }
 
 // H1 creates an <h1> element.
-func H1(attrs attrs.Props, children ...Node) *Element {
-	return newElement("h1", attrs, children...)
+func H1(children ...Node) *Element {
+	return newElement("h1", children...)
 }
 
 // H2 creates an <h2> element.
-func H2(attrs attrs.Props, children ...Node) *Element {
-	return newElement("h2", attrs, children...)
+func H2(children ...Node) *Element {
+	return newElement("h2", children...)
 }
 
 // H3 creates an <h3> element.
-func H3(attrs attrs.Props, children ...Node) *Element {
-	return newElement("h3", attrs, children...)
+func H3(children ...Node) *Element {
+	return newElement("h3", children...)
 }
 
 // H4 creates an <h4> element.
-func H4(attrs attrs.Props, children ...Node) *Element {
-	return newElement("h4", attrs, children...)
+func H4(children ...Node) *Element {
+	return newElement("h4", children...)
 }
 
 // H5 creates an <h5> element.
-func H5(attrs attrs.Props, children ...Node) *Element {
-	return newElement("h5", attrs, children...)
+func H5(children ...Node) *Element {
+	return newElement("h5", children...)
 }
 
 // H6 creates an <h6> element.
-func H6(attrs attrs.Props, children ...Node) *Element {
-	return newElement("h6", attrs, children...)
+func H6(children ...Node) *Element {
+	return newElement("h6", children...)
 }
 
 // Hgroup creates an <hgroup> element.
-func Hgroup(attrs attrs.Props, children ...Node) *Element {
-	return newElement("hgroup", attrs, children...)
+func Hgroup(children ...Node) *Element {
+	return newElement("hgroup", children...)
 }
 
 // Hr creates an <hr> element.
@@ -99,48 +99,48 @@ func Hr(attrs attrs.Props) *Element {
 }
 
 // I creates an <i> element.
-func I(attrs attrs.Props, children ...Node) *Element {
-	return newElement("i", attrs, children...)
+func I(children ...Node) *Element {
+	return newElement("i", children...)
 }
 
 // P creates a <p> element.
-func P(attrs attrs.Props, children ...Node) *Element {
-	return newElement("p", attrs, children...)
+func P(children ...Node) *Element {
+	return newElement("p", children...)
 }
 
 // Pre creates a <pre> element.
-func Pre(attrs attrs.Props, children ...Node) *Element {
-	return newElement("pre", attrs, children...)
+func Pre(children ...Node) *Element {
+	return newElement("pre", children...)
 }
 
 // Span creates a <span> element.
-func Span(attrs attrs.Props, children ...Node) *Element {
-	return newElement("span", attrs, children...)
+func Span(children ...Node) *Element {
+	return newElement("span", children...)
 }
 
 // Strong creates a <strong> element.
-func Strong(attrs attrs.Props, children ...Node) *Element {
-	return newElement("strong", attrs, children...)
+func Strong(children ...Node) *Element {
+	return newElement("strong", children...)
 }
 
 // Sub creates a <sub> element.
-func Sub(attrs attrs.Props, children ...Node) *Element {
-	return newElement("sub", attrs, children...)
+func Sub(children ...Node) *Element {
+	return newElement("sub", children...)
 }
 
 // Sup creates a <sub> element.
-func Sup(attrs attrs.Props, children ...Node) *Element {
-	return newElement("sup", attrs, children...)
+func Sup(children ...Node) *Element {
+	return newElement("sup", children...)
 }
 
 // B creates a <b> element.
-func B(attrs attrs.Props, children ...Node) *Element {
-	return newElement("b", attrs, children...)
+func B(children ...Node) *Element {
+	return newElement("b", children...)
 }
 
 // U creates a <u> element.
-func U(attrs attrs.Props, children ...Node) *Element {
-	return newElement("u", attrs, children...)
+func U(children ...Node) *Element {
+	return newElement("u", children...)
 }
 
 // Text creates a TextNode.
@@ -156,45 +156,45 @@ func Comment(comment string) CommentNode {
 // ========== Lists ==========
 
 // Li creates an <li> element.
-func Li(attrs attrs.Props, children ...Node) *Element {
-	return newElement("li", attrs, children...)
+func Li(children ...Node) *Element {
+	return newElement("li", children...)
 }
 
 // Ul creates a <ul> element.
-func Ul(attrs attrs.Props, children ...Node) *Element {
-	return newElement("ul", attrs, children...)
+func Ul(children ...Node) *Element {
+	return newElement("ul", children...)
 }
 
 // Ol creates an <ol> element.
-func Ol(attrs attrs.Props, children ...Node) *Element {
-	return newElement("ol", attrs, children...)
+func Ol(children ...Node) *Element {
+	return newElement("ol", children...)
 }
 
 // Dl creates a <dl> element.
-func Dl(attrs attrs.Props, children ...Node) *Element {
-	return newElement("dl", attrs, children...)
+func Dl(children ...Node) *Element {
+	return newElement("dl", children...)
 }
 
 // Dt creates a <dt> element.
-func Dt(attrs attrs.Props, children ...Node) *Element {
-	return newElement("dt", attrs, children...)
+func Dt(children ...Node) *Element {
+	return newElement("dt", children...)
 }
 
 // Dd creates a <dd> element.
-func Dd(attrs attrs.Props, children ...Node) *Element {
-	return newElement("dd", attrs, children...)
+func Dd(children ...Node) *Element {
+	return newElement("dd", children...)
 }
 
 // ========== Forms ==========
 
 // Button creates a <button> element.
-func Button(attrs attrs.Props, children ...Node) *Element {
-	return newElement("button", attrs, children...)
+func Button(children ...Node) *Element {
+	return newElement("button", children...)
 }
 
 // Form creates a <form> element.
-func Form(attrs attrs.Props, children ...Node) *Element {
-	return newElement("form", attrs, children...)
+func Form(children ...Node) *Element {
+	return newElement("form", children...)
 }
 
 // Input creates an <input> element.
@@ -203,28 +203,30 @@ func Input(attrs attrs.Props) *Element {
 }
 
 // Label creates a <label> element.
-func Label(attrs attrs.Props, children ...Node) *Element {
-	return newElement("label", attrs, children...)
+func Label(children ...Node) *Element {
+	return newElement("label", children...)
 }
 
 // Optgroup creates an <optgroup> element to group <option>s within a <select> element.
-func Optgroup(attrs attrs.Props, children ...Node) *Element {
-	return newElement("optgroup", attrs, children...)
+func Optgroup(children ...Node) *Element {
+	return newElement("optgroup", children...)
 }
 
 // Option creates an <option> element.
-func Option(attrs attrs.Props, content TextNode) *Element {
-	return newElement("option", attrs, content)
+// TODO this will not be 100% correct
+func Option(children ...Node) *Element {
+	return newElement("option", children...)
 }
 
 // Select creates a <select> element.
-func Select(attrs attrs.Props, children ...Node) *Element {
-	return newElement("select", attrs, children...)
+func Select(children ...Node) *Element {
+	return newElement("select", children...)
 }
 
 // Textarea creates a <textarea> element.
-func Textarea(attrs attrs.Props, content TextNode) *Element {
-	return newElement("textarea", attrs, content)
+// This will also not be 100% correct
+func Textarea(children ...Node) *Element {
+	return newElement("textarea", children...)
 }
 
 // ========== Hyperlinks and Multimedia ==========
@@ -252,13 +254,13 @@ func Meta(attrs attrs.Props) *Element {
 }
 
 // Script creates a <script> element.
-func Script(attrs attrs.Props, children ...Node) *Element {
-	return newElement("script", attrs, children...)
+func Script(children ...Node) *Element {
+	return newElement("script", children...)
 }
 
 // Style creates a <style> element.
-func Style(attrs attrs.Props, children ...Node) *Element {
-	return newElement("style", attrs, children...)
+func Style(children ...Node) *Element {
+	return newElement("style", children...)
 }
 
 // ========== Semantic Elements ==========
@@ -266,247 +268,247 @@ func Style(attrs attrs.Props, children ...Node) *Element {
 // --- Semantic Sectioning Elements ---
 
 // Article creates an <article> element.
-func Article(attrs attrs.Props, children ...Node) *Element {
-	return newElement("article", attrs, children...)
+func Article(children ...Node) *Element {
+	return newElement("article", children...)
 }
 
 // Aside creates an <aside> element.
-func Aside(attrs attrs.Props, children ...Node) *Element {
-	return newElement("aside", attrs, children...)
+func Aside(children ...Node) *Element {
+	return newElement("aside", children...)
 }
 
 // Footer creates a <footer> element.
-func Footer(attrs attrs.Props, children ...Node) *Element {
-	return newElement("footer", attrs, children...)
+func Footer(children ...Node) *Element {
+	return newElement("footer", children...)
 }
 
 // Header creates a <header> element.
-func Header(attrs attrs.Props, children ...Node) *Element {
-	return newElement("header", attrs, children...)
+func Header(children ...Node) *Element {
+	return newElement("header", children...)
 }
 
 // Main creates a <main> element.
-func Main(attrs attrs.Props, children ...Node) *Element {
-	return newElement("main", attrs, children...)
+func Main(children ...Node) *Element {
+	return newElement("main", children...)
 }
 
 // Nav creates a <nav> element.
-func Nav(attrs attrs.Props, children ...Node) *Element {
-	return newElement("nav", attrs, children...)
+func Nav(children ...Node) *Element {
+	return newElement("nav", children...)
 }
 
 // Section creates a <section> element.
-func Section(attrs attrs.Props, children ...Node) *Element {
-	return newElement("section", attrs, children...)
+func Section(children ...Node) *Element {
+	return newElement("section", children...)
 }
 
 // Details creates a <details> element.
-func Details(attrs attrs.Props, children ...Node) *Element {
-	return newElement("details", attrs, children...)
+func Details(children ...Node) *Element {
+	return newElement("details", children...)
 }
 
 // Summary creates a <summary> element.
-func Summary(attrs attrs.Props, children ...Node) *Element {
-	return newElement("summary", attrs, children...)
+func Summary(children ...Node) *Element {
+	return newElement("summary", children...)
 }
 
 // ========== Semantic Form Elements ==========
 
 // Fieldset creates a <fieldset> element.
-func Fieldset(attrs attrs.Props, children ...Node) *Element {
-	return newElement("fieldset", attrs, children...)
+func Fieldset(children ...Node) *Element {
+	return newElement("fieldset", children...)
 }
 
 // Legend creates a <legend> element.
-func Legend(attrs attrs.Props, children ...Node) *Element {
-	return newElement("legend", attrs, children...)
+func Legend(children ...Node) *Element {
+	return newElement("legend", children...)
 }
 
 // Datalist creates a <datalist> element.
-func Datalist(attrs attrs.Props, children ...Node) *Element {
-	return newElement("datalist", attrs, children...)
+func Datalist(children ...Node) *Element {
+	return newElement("datalist", children...)
 }
 
 // Meter creates a <meter> element.
-func Meter(attrs attrs.Props, children ...Node) *Element {
-	return newElement("meter", attrs, children...)
+func Meter(children ...Node) *Element {
+	return newElement("meter", children...)
 }
 
 // Output creates an <output> element.
-func Output(attrs attrs.Props, children ...Node) *Element {
-	return newElement("output", attrs, children...)
+func Output(children ...Node) *Element {
+	return newElement("output", children...)
 }
 
 // Progress creates a <progress> element.
-func Progress(attrs attrs.Props, children ...Node) *Element {
-	return newElement("progress", attrs, children...)
+func Progress(children ...Node) *Element {
+	return newElement("progress", children...)
 }
 
 // --- Semantic Interactive Elements ---
 
 // Dialog creates a <dialog> element.
-func Dialog(attrs attrs.Props, children ...Node) *Element {
-	return newElement("dialog", attrs, children...)
+func Dialog(children ...Node) *Element {
+	return newElement("dialog", children...)
 }
 
 // Menu creates a <menu> element.
-func Menu(attrs attrs.Props, children ...Node) *Element {
-	return newElement("menu", attrs, children...)
+func Menu(children ...Node) *Element {
+	return newElement("menu", children...)
 }
 
 // --- Semantic Script Supporting Elements ---
 
 // NoScript creates a <noscript> element.
-func NoScript(attrs attrs.Props, children ...Node) *Element {
-	return newElement("noscript", attrs, children...)
+func NoScript(children ...Node) *Element {
+	return newElement("noscript", children...)
 }
 
 // --- Semantic Text Content Elements ---
 
 // Abbr creates an <abbr> element.
-func Abbr(attrs attrs.Props, children ...Node) *Element {
-	return newElement("abbr", attrs, children...)
+func Abbr(children ...Node) *Element {
+	return newElement("abbr", children...)
 }
 
 // Address creates an <address> element.
-func Address(attrs attrs.Props, children ...Node) *Element {
-	return newElement("address", attrs, children...)
+func Address(children ...Node) *Element {
+	return newElement("address", children...)
 }
 
 // Cite creates a <cite> element.
-func Cite(attrs attrs.Props, children ...Node) *Element {
-	return newElement("cite", attrs, children...)
+func Cite(children ...Node) *Element {
+	return newElement("cite", children...)
 }
 
 // Data creates a <data> element.
-func Data(attrs attrs.Props, children ...Node) *Element {
-	return newElement("data", attrs, children...)
+func Data(children ...Node) *Element {
+	return newElement("data", children...)
 }
 
 // FigCaption creates a <figcaption> element.
-func FigCaption(attrs attrs.Props, children ...Node) *Element {
-	return newElement("figcaption", attrs, children...)
+func FigCaption(children ...Node) *Element {
+	return newElement("figcaption", children...)
 }
 
 // Figure creates a <figure> element.
-func Figure(attrs attrs.Props, children ...Node) *Element {
-	return newElement("figure", attrs, children...)
+func Figure(children ...Node) *Element {
+	return newElement("figure", children...)
 }
 
 // Kbd creates a <kbd> element.
-func Kbd(attrs attrs.Props, children ...Node) *Element {
-	return newElement("kbd", attrs, children...)
+func Kbd(children ...Node) *Element {
+	return newElement("kbd", children...)
 }
 
 // Mark creates a <mark> element.
-func Mark(attrs attrs.Props, children ...Node) *Element {
-	return newElement("mark", attrs, children...)
+func Mark(children ...Node) *Element {
+	return newElement("mark", children...)
 }
 
 // Q creates a <q> element.
-func Q(attrs attrs.Props, children ...Node) *Element {
-	return newElement("q", attrs, children...)
+func Q(children ...Node) *Element {
+	return newElement("q", children...)
 }
 
 // Samp creates a <samp> element.
-func Samp(attrs attrs.Props, children ...Node) *Element {
-	return newElement("samp", attrs, children...)
+func Samp(children ...Node) *Element {
+	return newElement("samp", children...)
 }
 
 // Small creates a <small> element.
-func Small(attrs attrs.Props, children ...Node) *Element {
-	return newElement("small", attrs, children...)
+func Small(children ...Node) *Element {
+	return newElement("small", children...)
 }
 
 // Time creates a <time> element.
-func Time(attrs attrs.Props, children ...Node) *Element {
-	return newElement("time", attrs, children...)
+func Time(children ...Node) *Element {
+	return newElement("time", children...)
 }
 
 // Var creates a <var> element.
-func Var(attrs attrs.Props, children ...Node) *Element {
-	return newElement("var", attrs, children...)
+func Var(children ...Node) *Element {
+	return newElement("var", children...)
 }
 
 // Ruby creates a <ruby> element.
-func Ruby(attrs attrs.Props, children ...Node) *Element {
-	return newElement("ruby", attrs, children...)
+func Ruby(children ...Node) *Element {
+	return newElement("ruby", children...)
 }
 
 // Rt creates a <rt> element.
-func Rt(attrs attrs.Props, children ...Node) *Element {
-	return newElement("rt", attrs, children...)
+func Rt(children ...Node) *Element {
+	return newElement("rt", children...)
 }
 
 // Rp creates a <rp> element.
-func Rp(attrs attrs.Props, children ...Node) *Element {
-	return newElement("rp", attrs, children...)
+func Rp(children ...Node) *Element {
+	return newElement("rp", children...)
 }
 
 // ========== Tables ==========
 
 // Table creates a <table> element.
-func Table(attrs attrs.Props, children ...Node) *Element {
-	return newElement("table", attrs, children...)
+func Table(children ...Node) *Element {
+	return newElement("table", children...)
 }
 
 // THead creates a <thead> element.
-func THead(attrs attrs.Props, children ...Node) *Element {
-	return newElement("thead", attrs, children...)
+func THead(children ...Node) *Element {
+	return newElement("thead", children...)
 }
 
 // TBody creates a <tbody> element.
-func TBody(attrs attrs.Props, children ...Node) *Element {
-	return newElement("tbody", attrs, children...)
+func TBody(children ...Node) *Element {
+	return newElement("tbody", children...)
 }
 
 // TFoot creates a <tfoot> element.
-func TFoot(attrs attrs.Props, children ...Node) *Element {
-	return newElement("tfoot", attrs, children...)
+func TFoot(children ...Node) *Element {
+	return newElement("tfoot", children...)
 }
 
 // Tr creates a <tr> element.
-func Tr(attrs attrs.Props, children ...Node) *Element {
-	return newElement("tr", attrs, children...)
+func Tr(children ...Node) *Element {
+	return newElement("tr", children...)
 }
 
 // Th creates a <th> element.
-func Th(attrs attrs.Props, children ...Node) *Element {
-	return newElement("th", attrs, children...)
+func Th(children ...Node) *Element {
+	return newElement("th", children...)
 }
 
 // Td creates a <td> element.
-func Td(attrs attrs.Props, children ...Node) *Element {
-	return newElement("td", attrs, children...)
+func Td(children ...Node) *Element {
+	return newElement("td", children...)
 }
 
 // ========== Embedded Content ==========
 
 // IFrames creates an <iframe> element.
-func IFrame(attrs attrs.Props, children ...Node) *Element {
-	return newElement("iframe", attrs, children...)
+func IFrame(children ...Node) *Element {
+	return newElement("iframe", children...)
 }
 
 // Audio creates an <audio> element.
-func Audio(attrs attrs.Props, children ...Node) *Element {
-	return newElement("audio", attrs, children...)
+func Audio(children ...Node) *Element {
+	return newElement("audio", children...)
 }
 
 // Video creates a <video> element.
-func Video(attrs attrs.Props, children ...Node) *Element {
-	return newElement("video", attrs, children...)
+func Video(children ...Node) *Element {
+	return newElement("video", children...)
 }
 
 // Source creates a <source> element.
-func Source(attrs attrs.Props, children ...Node) *Element {
-	return newElement("source", attrs, children...)
+func Source(children ...Node) *Element {
+	return newElement("source", children...)
 }
 
 // ========== Image Map Elements ==========
 
 // Map creates a <map> element.
-func Map(attrs attrs.Props, children ...Node) *Element {
-	return newElement("map", attrs, children...)
+func Map(children ...Node) *Element {
+	return newElement("map", children...)
 }
 
 // Area creates an <area> element.

--- a/elements_test.go
+++ b/elements_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/chasefleming/elem-go/attrs"
+	"github.com/chasefleming/elem-go/options"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,18 +12,18 @@ import (
 
 func TestBody(t *testing.T) {
 	expected := `<body class="page-body"><p>Welcome to Elem!</p></body>`
-	el := Body(attrs.Props{attrs.Class: "page-body"}, P(nil, Text("Welcome to Elem!")))
+	el := Body(attrs.Props{attrs.Class: "page-body"}, P(Text("Welcome to Elem!")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestHtml(t *testing.T) {
 	expected := `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Elem Page</title></head><body><p>Welcome to Elem!</p></body></html>`
 	el := Html(attrs.Props{attrs.Lang: "en"},
-		Head(nil,
+		Head(
 			Meta(attrs.Props{attrs.Charset: "UTF-8"}),
-			Title(nil, Text("Elem Page")),
+			Title(Text("Elem Page")),
 		),
-		Body(nil, P(nil, Text("Welcome to Elem!"))),
+		Body(P(Text("Welcome to Elem!"))),
 	)
 	assert.Equal(t, expected, el.Render())
 }
@@ -30,13 +31,13 @@ func TestHtml(t *testing.T) {
 func TestHtmlWithOptions(t *testing.T) {
 	expected := `<html lang="en"><head><meta charset="UTF-8"><title>Elem Page</title></head><body><p>Welcome to Elem!</p></body></html>`
 	el := Html(attrs.Props{attrs.Lang: "en"},
-		Head(nil,
+		Head(
 			Meta(attrs.Props{attrs.Charset: "UTF-8"}),
-			Title(nil, Text("Elem Page")),
+			Title(Text("Elem Page")),
 		),
-		Body(nil, P(nil, Text("Welcome to Elem!"))),
+		Body(P(Text("Welcome to Elem!"))),
 	)
-	assert.Equal(t, expected, el.RenderWithOptions(RenderOptions{DisableHtmlPreamble: true}))
+	assert.Equal(t, expected, el.RenderWithOptions(options.RenderOptions{DisableHtmlPreamble: true}))
 }
 
 // ========== Text Formatting and Structure ==========
@@ -49,7 +50,7 @@ func TestA(t *testing.T) {
 
 func TestBlockquote(t *testing.T) {
 	expected := `<blockquote>Quote text</blockquote>`
-	el := Blockquote(nil, Text("Quote text"))
+	el := Blockquote(Text("Quote text"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -61,7 +62,7 @@ func TestBr(t *testing.T) {
 
 func TestCode(t *testing.T) {
 	expected := `<code>Code snippet</code>`
-	el := Code(nil, Text("Code snippet"))
+	el := Code(Text("Code snippet"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -73,7 +74,7 @@ func TestDiv(t *testing.T) {
 
 func TestEm(t *testing.T) {
 	expected := `<em>Italic text</em>`
-	el := Em(nil, Text("Italic text"))
+	el := Em(Text("Italic text"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -91,25 +92,25 @@ func TestH2(t *testing.T) {
 
 func TestH3(t *testing.T) {
 	expected := `<h3>Hello, Elem!</h3>`
-	el := H3(nil, Text("Hello, Elem!"))
+	el := H3(Text("Hello, Elem!"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestH4(t *testing.T) {
 	expected := `<h4>Hello, Elem!</h4>`
-	el := H4(nil, Text("Hello, Elem!"))
+	el := H4(Text("Hello, Elem!"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestH5(t *testing.T) {
 	expected := `<h5>Hello, Elem!</h5>`
-	el := H5(nil, Text("Hello, Elem!"))
+	el := H5(Text("Hello, Elem!"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestH6(t *testing.T) {
 	expected := `<h6>Hello, Elem!</h6>`
-	el := H6(nil, Text("Hello, Elem!"))
+	el := H6(Text("Hello, Elem!"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -122,7 +123,7 @@ func TestHr(t *testing.T) {
 func TestI(t *testing.T) {
 	expected1 := `<i>Idiomatic Text</i>`
 	expected2 := `<i class="fa-regular fa-face-smile"></i>`
-	el := I(nil, Text("Idiomatic Text"))
+	el := I(Text("Idiomatic Text"))
 	assert.Equal(t, expected1, el.Render())
 	el = I(attrs.Props{attrs.Class: "fa-regular fa-face-smile"})
 	assert.Equal(t, expected2, el.Render())
@@ -130,13 +131,13 @@ func TestI(t *testing.T) {
 
 func TestP(t *testing.T) {
 	expected := `<p>Hello, Elem!</p>`
-	el := P(nil, Text("Hello, Elem!"))
+	el := P(Text("Hello, Elem!"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestPre(t *testing.T) {
 	expected := `<pre>Preformatted text</pre>`
-	el := Pre(nil, Text("Preformatted text"))
+	el := Pre(Text("Preformatted text"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -148,31 +149,31 @@ func TestSpan(t *testing.T) {
 
 func TestStrong(t *testing.T) {
 	expected := `<strong>Bold text</strong>`
-	el := Strong(nil, Text("Bold text"))
+	el := Strong(Text("Bold text"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestSub(t *testing.T) {
 	expected := `<sub>2</sub>`
-	el := Sub(nil, Text("2"))
+	el := Sub(Text("2"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestSup(t *testing.T) {
 	expected := `<sup>2</sup>`
-	el := Sup(nil, Text("2"))
+	el := Sup(Text("2"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestB(t *testing.T) {
 	expected := `<b>Important text</b>`
-	el := B(nil, Text("Important text"))
+	el := B(Text("Important text"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestU(t *testing.T) {
 	expected := `<u>Unarticulated text</u>`
-	el := U(nil, Text("Unarticulated text"))
+	el := U(Text("Unarticulated text"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -185,7 +186,7 @@ func TestComment(t *testing.T) {
 
 func TestCommentInElement(t *testing.T) {
 	expected := `<div>not a comment<!-- this is a comment --></div>`
-	actual := Div(nil, Text("not a comment"), Comment("this is a comment")).Render()
+	actual := Div(Text("not a comment"), Comment("this is a comment")).Render()
 	assert.Equal(t, expected, actual)
 }
 
@@ -193,37 +194,37 @@ func TestCommentInElement(t *testing.T) {
 
 func TestLi(t *testing.T) {
 	expected := `<li>Item 1</li>`
-	el := Li(nil, Text("Item 1"))
+	el := Li(Text("Item 1"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestUl(t *testing.T) {
 	expected := `<ul><li>Item 1</li><li>Item 2</li></ul>`
-	el := Ul(nil, Li(nil, Text("Item 1")), Li(nil, Text("Item 2")))
+	el := Ul(Li(Text("Item 1")), Li(Text("Item 2")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestOl(t *testing.T) {
 	expected := `<ol><li>Item 1</li><li>Item 2</li></ol>`
-	el := Ol(nil, Li(nil, Text("Item 1")), Li(nil, Text("Item 2")))
+	el := Ol(Li(Text("Item 1")), Li(Text("Item 2")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestDl(t *testing.T) {
 	expected := `<dl><dt>Term 1</dt><dd>Description 1</dd><dt>Term 2</dt><dd>Description 2</dd></dl>`
-	el := Dl(nil, Dt(nil, Text("Term 1")), Dd(nil, Text("Description 1")), Dt(nil, Text("Term 2")), Dd(nil, Text("Description 2")))
+	el := Dl(Dt(Text("Term 1")), Dd(Text("Description 1")), Dt(Text("Term 2")), Dd(Text("Description 2")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestDt(t *testing.T) {
 	expected := `<dt>Term 1</dt>`
-	el := Dt(nil, Text("Term 1"))
+	el := Dt(Text("Term 1"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestDd(t *testing.T) {
 	expected := `<dd>Description 1</dd>`
-	el := Dd(nil, Text("Description 1"))
+	el := Dd(Text("Description 1"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -337,49 +338,49 @@ func TestStyle(t *testing.T) {
 
 func TestArticle(t *testing.T) {
 	expected := `<article><h2>Article Title</h2><p>Article content.</p></article>`
-	el := Article(nil, H2(nil, Text("Article Title")), P(nil, Text("Article content.")))
+	el := Article(H2(Text("Article Title")), P(Text("Article content.")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestAside(t *testing.T) {
 	expected := `<aside><p>Sidebar content.</p></aside>`
-	el := Aside(nil, P(nil, Text("Sidebar content.")))
+	el := Aside(P(Text("Sidebar content.")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestFooter(t *testing.T) {
 	expected := `<footer><p>Footer content.</p></footer>`
-	el := Footer(nil, P(nil, Text("Footer content.")))
+	el := Footer(P(Text("Footer content.")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestHeader(t *testing.T) {
 	expected := `<header class="site-header"><h1>Welcome to Elem!</h1></header>`
-	el := Header(attrs.Props{attrs.Class: "site-header"}, H1(nil, Text("Welcome to Elem!")))
+	el := Header(attrs.Props{attrs.Class: "site-header"}, H1(Text("Welcome to Elem!")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestMainElem(t *testing.T) {
 	expected := `<main><p>Main content goes here.</p></main>`
-	el := Main(nil, P(nil, Text("Main content goes here.")))
+	el := Main(P(Text("Main content goes here.")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestNav(t *testing.T) {
 	expected := `<nav><a href="/home">Home</a><a href="/about">About</a></nav>`
-	el := Nav(nil, A(attrs.Props{attrs.Href: "/home"}, Text("Home")), A(attrs.Props{attrs.Href: "/about"}, Text("About")))
+	el := Nav(A(attrs.Props{attrs.Href: "/home"}, Text("Home")), A(attrs.Props{attrs.Href: "/about"}, Text("About")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestSection(t *testing.T) {
 	expected := `<section><h3>Section Title</h3><p>Section content.</p></section>`
-	el := Section(nil, H3(nil, Text("Section Title")), P(nil, Text("Section content.")))
+	el := Section(H3(Text("Section Title")), P(Text("Section content.")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestHgroup(t *testing.T) {
 	expected := `<hgroup><h1>Frankenstein</h1><p>Or: The Modern Prometheus</p></hgroup>`
-	el := Hgroup(nil, H1(nil, Text("Frankenstein")), P(nil, Text("Or: The Modern Prometheus")))
+	el := Hgroup(H1(Text("Frankenstein")), P(Text("Or: The Modern Prometheus")))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -387,7 +388,7 @@ func TestHgroup(t *testing.T) {
 
 func TestFieldset(t *testing.T) {
 	expected := `<fieldset class="custom-fieldset"><legend>Personal Information</legend><input name="name" type="text"></fieldset>`
-	el := Fieldset(attrs.Props{attrs.Class: "custom-fieldset"}, Legend(nil, Text("Personal Information")), Input(attrs.Props{attrs.Type: "text", attrs.Name: "name"}))
+	el := Fieldset(attrs.Props{attrs.Class: "custom-fieldset"}, Legend(Text("Personal Information")), Input(attrs.Props{attrs.Type: "text", attrs.Name: "name"}))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -425,13 +426,13 @@ func TestProgress(t *testing.T) {
 
 func TestDialog(t *testing.T) {
 	expected := `<dialog open><p>This is an open dialog window</p></dialog>`
-	el := Dialog(attrs.Props{attrs.Open: "true"}, P(nil, Text("This is an open dialog window")))
+	el := Dialog(attrs.Props{attrs.Open: "true"}, P(Text("This is an open dialog window")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestMenu(t *testing.T) {
 	expected := `<menu><li>Item One</li><li>Item Two</li></menu>`
-	el := Menu(nil, Li(nil, Text("Item One")), Li(nil, Text("Item Two")))
+	el := Menu(Li(Text("Item One")), Li(Text("Item Two")))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -439,7 +440,7 @@ func TestMenu(t *testing.T) {
 
 func TestNoScript(t *testing.T) {
 	expected := `<noscript><p>JavaScript is required for this application.</p></noscript>`
-	el := NoScript(nil, P(nil, Text("JavaScript is required for this application.")))
+	el := NoScript(P(Text("JavaScript is required for this application.")))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -453,31 +454,31 @@ func TestAbbr(t *testing.T) {
 
 func TestAddress(t *testing.T) {
 	expected := `<address>123 Example St.</address>`
-	el := Address(nil, Text("123 Example St."))
+	el := Address(Text("123 Example St."))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestCite(t *testing.T) {
 	expected := `<p>My favorite book is <cite>The Reality Dysfunction</cite> by Peter F. Hamilton.</p>`
-	el := P(nil, Text("My favorite book is "), Cite(nil, Text("The Reality Dysfunction")), Text(" by Peter F. Hamilton."))
+	el := P(Text("My favorite book is "), Cite(Text("The Reality Dysfunction")), Text(" by Peter F. Hamilton."))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestDetails(t *testing.T) {
 	expected := `<details><summary>More Info</summary><p>Details content here.</p></details>`
-	el := Details(nil, Summary(nil, Text("More Info")), P(nil, Text("Details content here.")))
+	el := Details(Summary(Text("More Info")), P(Text("Details content here.")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestDetailsWithOpenFalse(t *testing.T) {
 	expected := `<details><summary>More Info</summary><p>Details content here.</p></details>`
-	el := Details(attrs.Props{attrs.Open: "false"}, Summary(nil, Text("More Info")), P(nil, Text("Details content here.")))
+	el := Details(attrs.Props{attrs.Open: "false"}, Summary(Text("More Info")), P(Text("Details content here.")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestDetailsWithOpenTrue(t *testing.T) {
 	expected := `<details open><summary>More Info</summary><p>Details content here.</p></details>`
-	el := Details(attrs.Props{attrs.Open: "true"}, Summary(nil, Text("More Info")), P(nil, Text("Details content here.")))
+	el := Details(attrs.Props{attrs.Open: "true"}, Summary(Text("More Info")), P(Text("Details content here.")))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -489,49 +490,49 @@ func TestData(t *testing.T) {
 
 func TestFigCaption(t *testing.T) {
 	expected := `<figcaption>Description of the figure.</figcaption>`
-	el := FigCaption(nil, Text("Description of the figure."))
+	el := FigCaption(Text("Description of the figure."))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestFigure(t *testing.T) {
 	expected := `<figure><img alt="An image" src="image.jpg"><figcaption>An image</figcaption></figure>`
-	el := Figure(nil, Img(attrs.Props{attrs.Src: "image.jpg", attrs.Alt: "An image"}), FigCaption(nil, Text("An image")))
+	el := Figure(Img(attrs.Props{attrs.Src: "image.jpg", attrs.Alt: "An image"}), FigCaption(Text("An image")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestKbd(t *testing.T) {
 	expected := `<p>To make George eat an apple, select <kbd>File | Eat Apple...</kbd></p>`
-	el := P(nil, Text("To make George eat an apple, select "), Kbd(nil, Text("File | Eat Apple...")))
+	el := P(Text("To make George eat an apple, select "), Kbd(Text("File | Eat Apple...")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestMark(t *testing.T) {
 	expected := `<p>You must <mark>highlight</mark> this word.</p>`
-	el := P(nil, Text("You must "), Mark(nil, Text("highlight")), Text(" this word."))
+	el := P(Text("You must "), Mark(Text("highlight")), Text(" this word."))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestQ(t *testing.T) {
 	expected := `<p>The W3C's mission is <q cite="https://www.w3.org/Consortium/">To lead the World Wide Web to its full potential</q>.</p>`
-	el := P(nil, Text("The W3C's mission is "), Q(attrs.Props{attrs.Cite: "https://www.w3.org/Consortium/"}, Text("To lead the World Wide Web to its full potential")), Text("."))
+	el := P(Text("The W3C's mission is "), Q(attrs.Props{attrs.Cite: "https://www.w3.org/Consortium/"}, Text("To lead the World Wide Web to its full potential")), Text("."))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestSamp(t *testing.T) {
 	expected := `<p>The computer said <samp>Too much cheese in tray two</samp> but I didn't know what that meant.</p>`
-	el := P(nil, Text("The computer said "), Samp(nil, Text("Too much cheese in tray two")), Text(" but I didn't know what that meant."))
+	el := P(Text("The computer said "), Samp(Text("Too much cheese in tray two")), Text(" but I didn't know what that meant."))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestSmall(t *testing.T) {
 	expected := `<p>Single room <small>breakfast included, VAT not included</small></p>`
-	el := P(nil, Text("Single room "), Small(nil, Text("breakfast included, VAT not included")))
+	el := P(Text("Single room "), Small(Text("breakfast included, VAT not included")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestSummary(t *testing.T) {
 	expected := `<details><summary>Summary Title</summary></details>`
-	el := Details(nil, Summary(nil, Text("Summary Title")))
+	el := Details(Summary(Text("Summary Title")))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -543,25 +544,25 @@ func TestTime(t *testing.T) {
 
 func TestVar(t *testing.T) {
 	expected := `<p>After a few moment's thought, she wrote <var>E</var>.</p>`
-	el := P(nil, Text("After a few moment's thought, she wrote "), Var(nil, Text("E")), Text("."))
+	el := P(Text("After a few moment's thought, she wrote "), Var(Text("E")), Text("."))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestRuby(t *testing.T) {
 	expected := `<ruby>漢</ruby>`
-	el := Ruby(nil, Text("漢"))
+	el := Ruby(Text("漢"))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestRt(t *testing.T) {
 	expected := `<ruby> 漢 <rp>(</rp><rt>kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp> </ruby>`
-	el := Ruby(nil, Text(" 漢 "), Rp(nil, Text("(")), Rt(nil, Text("kan")), Rp(nil, Text(")")), Text(" 字 "), Rp(nil, Text("(")), Rt(nil, Text("ji")), Rp(nil, Text(")")), Text(" "))
+	el := Ruby(Text(" 漢 "), Rp(Text("(")), Rt(Text("kan")), Rp(Text(")")), Text(" 字 "), Rp(Text("(")), Rt(Text("ji")), Rp(Text(")")), Text(" "))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestRp(t *testing.T) {
 	expected := `<ruby> 漢 <rp>(</rp> 字 <rp>)</rp> </ruby>`
-	el := Ruby(nil, Text(" 漢 "), Rp(nil, Text("(")), Text(" 字 "), Rp(nil, Text(")")), Text(" "))
+	el := Ruby(Text(" 漢 "), Rp(Text("(")), Text(" 字 "), Rp(Text(")")), Text(" "))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -569,43 +570,43 @@ func TestRp(t *testing.T) {
 
 func TestTr(t *testing.T) {
 	expected := `<tr>Row content.</tr>`
-	el := Tr(nil, Text("Row content."))
+	el := Tr(Text("Row content."))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestTd(t *testing.T) {
 	expected := `<tr><td><h1>Cell one.</h1></td><td>Cell two.</td></tr>`
-	el := Tr(nil, Td(nil, H1(nil, Text("Cell one."))), Td(nil, Text("Cell two.")))
+	el := Tr(Td(H1(Text("Cell one."))), Td(Text("Cell two.")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestTh(t *testing.T) {
 	expected := `<tr><th>First name</th><th>Last name</th><th>Age</th></tr>`
-	el := Tr(nil, Th(nil, Text("First name")), Th(nil, Text("Last name")), Th(nil, Text("Age")))
+	el := Tr(Th(Text("First name")), Th(Text("Last name")), Th(Text("Age")))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestTHead(t *testing.T) {
 	expected := `<thead><tr><td>Text</td><td><a href="/link">Link</a></td></tr></thead>`
-	el := THead(nil, Tr(nil, Td(nil, Text("Text")), Td(nil, A(attrs.Props{attrs.Href: "/link"}, Text("Link")))))
+	el := THead(Tr(Td(Text("Text")), Td(A(attrs.Props{attrs.Href: "/link"}, Text("Link")))))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestTBody(t *testing.T) {
 	expected := `<tbody><tr><td>Table body</td></tr></tbody>`
-	el := TBody(nil, Tr(nil, Td(nil, Text("Table body"))))
+	el := TBody(Tr(Td(Text("Table body"))))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestTFoot(t *testing.T) {
 	expected := `<tfoot><tr><td><a href="/footer">Table footer</a></td></tr></tfoot>`
-	el := TFoot(nil, Tr(nil, Td(nil, A(attrs.Props{attrs.Href: "/footer"}, Text("Table footer")))))
+	el := TFoot(Tr(Td(A(attrs.Props{attrs.Href: "/footer"}, Text("Table footer")))))
 	assert.Equal(t, expected, el.Render())
 }
 
 func TestTable(t *testing.T) {
 	expected := `<table><tr><th>Table header</th></tr><tr><td>Table content</td></tr></table>`
-	el := Table(nil, Tr(nil, Th(nil, Text("Table header"))), Tr(nil, Td(nil, Text("Table content"))))
+	el := Table(Tr(Th(Text("Table header"))), Tr(Td(Text("Table content"))))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -669,7 +670,7 @@ func TestNone(t *testing.T) {
 
 func TestNoneInDiv(t *testing.T) {
 	expected := `<div></div>`
-	actual := Div(nil, None()).Render()
+	actual := Div(None()).Render()
 	assert.Equal(t, expected, actual)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chasefleming/elem-go
 
-go 1.21.1
+go 1.21
 
 require github.com/stretchr/testify v1.8.4
 

--- a/options/opt.go
+++ b/options/opt.go
@@ -1,0 +1,6 @@
+package options
+
+type RenderOptions struct {
+	// DisableHtmlPreamble disables the doctype preamble for the HTML tag if it exists in the rendering tree
+	DisableHtmlPreamble bool
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestIf(t *testing.T) {
-	trueElement := Div(nil, Text("True Condition"))
-	falseElement := Div(nil, Text("False Condition"))
+	trueElement := Div(Text("True Condition"))
+	falseElement := Div(Text("False Condition"))
 
 	resultTrue := If(true, trueElement, falseElement)
 	assert.Equal(t, trueElement.Render(), resultTrue.Render())
@@ -18,7 +18,7 @@ func TestIf(t *testing.T) {
 }
 
 func TestIfUsingNone(t *testing.T) {
-	trueElement := Div(nil, Text("True Condition"))
+	trueElement := Div(Text("True Condition"))
 
 	resultWithNone := If[Node](true, trueElement, None())
 	assert.Equal(t, trueElement.Render(), resultWithNone.Render(), "If should render the true element when the condition is true")
@@ -31,7 +31,7 @@ func TestTransformEach(t *testing.T) {
 	items := []string{"Item 1", "Item 2", "Item 3"}
 
 	elements := TransformEach(items, func(item string) Node {
-		return Li(nil, Text(item))
+		return Li(Text(item))
 	})
 
 	assert.Equal(t, len(items), len(elements))


### PR DESCRIPTION
 - make attrs.Props a Node
 - when parsing new element check if first is props and if it is use it if else empty props.
 - some builders are now not 100% correct like TextArea can take any Node, this can be fixed though with some simple guards inside that one to allow only 1 textNode and props.
 - fixed tests to remove nil