### PR TITLE
Add `font-variant` property to styles

### DIFF
--- a/styles/constants.go
+++ b/styles/constants.go
@@ -105,6 +105,7 @@ const (
 	WordSpacing    = "word-spacing"
 	WordBreak      = "word-break"
 	TextIndent     = "text-indent"
+	FontVariant    = "font-variant"
 
 	// Visual Properties
 	BackgroundColor      = "background-color"


### PR DESCRIPTION
I would like to make use of the `font-variant` CSS property in a project of mine, this allows you to (among other things) set a font to be a `small-caps` variant which can add some visual appeal.

I simply added it to `constants.go`.

I also verified it worked by throwing a style onto the H1 element in the `htmx-fiber-todo` example, however I did not commit that change.