### PR TITLE
Add support for single quoted attrs

### DIFF
--- a/elem.go
+++ b/elem.go
@@ -194,11 +194,22 @@ func (e *Element) renderAttrTo(attrName string, builder *strings.Builder) {
 		}
 	} else {
 		// regular attribute has a name and a value
+		attrVal := e.Attrs[attrName]
+
+		// A necessary check to to avoid adding extra quotes around values that are already single-quoted
+		// An example is '{"quantity": 5}'
+		isSingleQuoted := strings.HasPrefix(attrVal, "'") && strings.HasSuffix(attrVal, "'")
+
 		builder.WriteString(` `)
 		builder.WriteString(attrName)
-		builder.WriteString(`="`)
-		builder.WriteString(e.Attrs[attrName])
-		builder.WriteString(`"`)
+		builder.WriteString(`=`)
+		if !isSingleQuoted {
+			builder.WriteString(`"`)
+		}
+		builder.WriteString(attrVal)
+		if !isSingleQuoted {
+			builder.WriteString(`"`)
+		}
 	}
 }
 

--- a/elements_test.go
+++ b/elements_test.go
@@ -687,3 +687,12 @@ func TestCSS(t *testing.T) {
 	el := CSS(cssContent)
 	assert.Equal(t, expected, el.Render())
 }
+
+func TestSingleQuote(t *testing.T) {
+	expected := `<div data-values='{"quantity": 5}'></div>`
+	el := Div(attrs.Props{
+		"data-values": `'{"quantity": 5}'`,
+	})
+	actual := el.Render()
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Now able to use single quotes as attribute values.

```go
Div(attrs.Props{
    "data-values": `'{"quantity": 5}'`,
})
```

### Previous output

```html
<div data-values="'{" quantity": 5}'"></div>
```

### New HTML output

```html
<div data-values='{"quantity": 5}'></div>
```

### Rendered by the browser

```html
<div data-values="{"quantity": 5}"></div>
```