### PR TITLE
Add support for nomodule attribute

### DIFF
--- a/attrs/attrs.go
+++ b/attrs/attrs.go
@@ -23,6 +23,7 @@ const (
 	Defer       = "defer"
 	Href        = "href"
 	Integrity   = "integrity"
+	Nomodule    = "nomodule"
 	Rel         = "rel"
 	Src         = "src"
 	Target      = "target"

--- a/elem.go
+++ b/elem.go
@@ -46,6 +46,7 @@ var booleanAttrs = map[string]struct{}{
 	attrs.Loop:            {},
 	attrs.Multiple:        {},
 	attrs.Muted:           {},
+	attrs.Nomodule:        {},
 	attrs.Novalidate:      {},
 	attrs.Open:            {},
 	attrs.Playsinline:     {},


### PR DESCRIPTION
This PR adds support for the [`nomodule`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#nomodule) attribute in `script` tags.