### PR TITLE
Add support for `as` attribute

### DIFF
--- a/attrs/attrs.go
+++ b/attrs/attrs.go
@@ -16,6 +16,7 @@ const (
 
 	// Link/Script Attributes
 
+	As    = "as"
 	Async = "async"
 	// Deprecated: Use Crossorigin instead
 	CrossOrigin = "crossorigin"


### PR DESCRIPTION
This PR adds support for the [`as`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#as) attribute in `link` tags in case the asset is [preloaded](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload).