### PR TITLE
Fix fiber counter example

### DIFF
--- a/examples/htmx-fiber-counter/main.go
+++ b/examples/htmx-fiber-counter/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	app := fiber.New()
 
-	var count int
+	count := 0
 
 	app.Post("/increment", func(c *fiber.Ctx) error {
 		count++
@@ -57,7 +57,7 @@ func main() {
 			attrs.Style: bodyStyle.ToInline(),
 		},
 			elem.H1(nil, elem.Text("Counter App")),
-			elem.Div(attrs.Props{attrs.ID: "count"}, elem.Text("0")),
+			elem.Div(attrs.Props{attrs.ID: "count"}, elem.Text(fmt.Sprintf("%d", count))),
 			elem.Button(attrs.Props{
 				htmx.HXPost:   "/increment",
 				htmx.HXTarget: "#count",


### PR DESCRIPTION
The value on initial page load is currently always 0, even if it had already been modified by clicking the increment or decrement buttons. This causes weird behavior when opening the page in multiple tabs.