### PR TITLE
added content escaping for text nodes

### DIFF
--- a/elem.go
+++ b/elem.go
@@ -92,15 +92,15 @@ func (n NoneNode) RenderWithOptions(opts RenderOptions) string {
 type TextNode string
 
 func (t TextNode) RenderTo(builder *strings.Builder, opts RenderOptions) {
-	builder.WriteString(string(t))
+	builder.WriteString(EscapeNodeContents(string(t)))
 }
 
 func (t TextNode) Render() string {
-	return string(t)
+	return EscapeNodeContents(string(t))
 }
 
 func (t TextNode) RenderWithOptions(opts RenderOptions) string {
-	return string(t)
+	return EscapeNodeContents(string(t))
 }
 
 type RawNode string

--- a/elements.go
+++ b/elements.go
@@ -143,7 +143,8 @@ func U(attrs attrs.Props, children ...Node) *Element {
 	return newElement("u", attrs, children...)
 }
 
-// Text creates a TextNode.
+// Text creates a TextNode, content is automatically escaped to ensure safe rendering.
+// For unescaped HTML, use Raw function instead.
 func Text(content string) TextNode {
 	return TextNode(content)
 }

--- a/elements_test.go
+++ b/elements_test.go
@@ -673,6 +673,24 @@ func TestNoneInDiv(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestText(t *testing.T) {
+	expected := `<p>Hello, World!</p>`
+	el := P(nil, Text("Hello, World!"))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestTextWithEscaping(t *testing.T) {
+	expected := `<p>Hello, &lt;em&gt;World!&lt;/em&gt;</p>`
+	el := P(nil, Text("Hello, <em>World!</em>"))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestTextWithNoQuotesEscaping(t *testing.T) {
+	expected := `<p>'Hello,' "World!"</p>`
+	el := P(nil, Text(`'Hello,' "World!"`))
+	assert.Equal(t, expected, el.Render())
+}
+
 func TestRaw(t *testing.T) {
 	rawHTML := `<div class="test"><p>Test paragraph</p></div>`
 	el := Raw(rawHTML)

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,15 @@ package elem
 
 import "strings"
 
+// nodeContentReplacer handles escaping of HTML special characters in text nodes
+// note that single and double quotes (', ") do not need escaping in HTML5 text nodes
+var nodeContentReplacer = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	// technically, > does not need escaping in HTML5, but we do it for consistency
+	">", "&gt;",
+)
+
 // If conditionally renders one of the provided elements based on the condition
 func If[T any](condition bool, ifTrue, ifFalse T) T {
 	if condition {
@@ -21,11 +30,5 @@ func TransformEach[T any](items []T, fn func(T) Node) []Node {
 
 // EscapeNodeContents escapes HTML5 special characters in a string to ensure safe rendering as a text node
 func EscapeNodeContents(s string) string {
-	s = strings.ReplaceAll(s, "&", "&amp;")
-	s = strings.ReplaceAll(s, "<", "&lt;")
-	// technically, > does not need escaping in HTML5, but we do it for consistency
-	s = strings.ReplaceAll(s, ">", "&gt;")
-	// note that single and double quotes (', ") do not need escaping in HTML5 text nodes
-
-	return s
+	return nodeContentReplacer.Replace(s)
 }

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,7 @@
 package elem
 
+import "strings"
+
 // If conditionally renders one of the provided elements based on the condition
 func If[T any](condition bool, ifTrue, ifFalse T) T {
 	if condition {
@@ -15,4 +17,15 @@ func TransformEach[T any](items []T, fn func(T) Node) []Node {
 		nodes = append(nodes, fn(item))
 	}
 	return nodes
+}
+
+// EscapeNodeContents escapes HTML5 special characters in a string to ensure safe rendering as a text node
+func EscapeNodeContents(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	// technically, > does not need escaping in HTML5, but we do it for consistency
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	// note that single and double quotes (', ") do not need escaping in HTML5 text nodes
+
+	return s
 }


### PR DESCRIPTION
# Description

`Text()` now escapes HTML5 special characters for safe rendering. `Raw()` is still available if you need to render code without escaping HTML5 elements — for example, if you need non-standard tags. 

Technically, only `&` and `<` need to be escaped, not `>`. I still escape `>` for consistency and the resulting code passes the validator.

# Some context

I accidentally ran into the problem that elements were not escaped in Text() and learned that there was no difference between Text and Raw nodes.