### PR TITLE
added support for CDATA element

### DIFF
--- a/elem.go
+++ b/elem.go
@@ -117,6 +117,24 @@ func (t RawNode) RenderWithOptions(opts RenderOptions) string {
 	return string(t)
 }
 
+type CdataNode string
+
+func (t CdataNode) RenderTo(builder *strings.Builder, opts RenderOptions) {
+	builder.WriteString("<![CDATA[")
+	builder.WriteString(EscapeCdataContents(string(t)))
+	builder.WriteString("]]>")
+}
+
+func (t CdataNode) Render() string {
+	return t.RenderWithOptions(RenderOptions{})
+}
+
+func (t CdataNode) RenderWithOptions(opts RenderOptions) string {
+	var builder strings.Builder
+	t.RenderTo(&builder, opts)
+	return builder.String()
+}
+
 type CommentNode string
 
 func (c CommentNode) RenderTo(builder *strings.Builder, opts RenderOptions) {

--- a/elements_test.go
+++ b/elements_test.go
@@ -176,6 +176,23 @@ func TestU(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+// ========= Cdata ==========
+func TestCdata(t *testing.T) {
+	expected := `<![CDATA[Some CDATA content]]>`
+	actual := CdataNode("Some CDATA content").Render()
+	assert.Equal(t, expected, actual)
+}
+
+func TestCdataEscaping (t *testing.T) {
+	expected := `<![CDATA[Some CDATA content with ]]&gt; in it]]>`
+	actual := CdataNode("Some CDATA content with ]]> in it").Render()
+	assert.Equal(t, expected, actual)
+
+	expected = `<![CDATA[These < and > should not be escaped]]>`
+	actual = CdataNode("These < and > should not be escaped").Render()
+	assert.Equal(t, expected, actual)
+}
+
 // ========== Comments ==========
 func TestComment(t *testing.T) {
 	expected := `<!-- this is a comment -->`

--- a/utils.go
+++ b/utils.go
@@ -40,6 +40,15 @@ func EscapeNodeContents(s string) string {
 	return nodeContentReplacer.Replace(s)
 }
 
+// EscapeCdataContents escapes the contents of a CDATA section to ensure safe rendering
+func EscapeCdataContents(s string) string {
+	// text in cdata must not contain the string "]]>"
+	if strings.Contains(s, "]]>") {
+		s = strings.ReplaceAll(s, "]]>", "]]&gt;")
+	}
+	return s
+}
+
 // EscapeCommentContents escapes the contents of a comment node to ensure safe rendering according to https://html.spec.whatwg.org/multipage/syntax.html#comments
 func EscapeCommentContents(s string) string {
 	s = commentContentsReplacer.Replace(s)


### PR DESCRIPTION
Adding support for the CDATA element with HTML5 and XML compatible escaping.

According to HTML5 and XML specifications, the only disallowed character sequence in CDATA is `]]>` (the closing element).