### PR TITLE
feat: add Ch and Ex helper functions for character-based CSS units

### DIFF
--- a/styles/utils.go
+++ b/styles/utils.go
@@ -50,6 +50,16 @@ func Rem(value float64) string {
 	return strconv.FormatFloat(value, 'f', 2, 64) + "rem"
 }
 
+// Ch returns a string representation of the given float as a character unit value.
+func Ch(value float64) string {
+	return strconv.FormatFloat(value, 'f', 2, 64) + "ch"
+}
+
+// Ex returns a string representation of the given float as an x-height unit value.
+func Ex(value float64) string {
+	return strconv.FormatFloat(value, 'f', 2, 64) + "ex"
+}
+
 // RGB returns a string representation of the given RGB values as a CSS RGB value.
 func RGB(r, g, b int) string {
 	var builder strings.Builder

--- a/styles/utils_test.go
+++ b/styles/utils_test.go
@@ -89,6 +89,26 @@ func TestRem(t *testing.T) {
 	assert.Equal(t, "25.00rem", Rem(25))
 }
 
+func TestCh(t *testing.T) {
+	assert.Equal(t, "100.00ch", Ch(100))
+	assert.Equal(t, "0.00ch", Ch(0))
+	assert.Equal(t, "50.00ch", Ch(50))
+	assert.Equal(t, "50.00ch", Ch(50.0))
+	assert.Equal(t, "50.00ch", Ch(50.00))
+	assert.Equal(t, "25.00ch", Ch(25))
+	assert.Equal(t, "2.50ch", Ch(2.5))
+}
+
+func TestEx(t *testing.T) {
+	assert.Equal(t, "100.00ex", Ex(100))
+	assert.Equal(t, "0.00ex", Ex(0))
+	assert.Equal(t, "50.00ex", Ex(50))
+	assert.Equal(t, "50.00ex", Ex(50.0))
+	assert.Equal(t, "50.00ex", Ex(50.00))
+	assert.Equal(t, "25.00ex", Ex(25))
+	assert.Equal(t, "2.50ex", Ex(2.5))
+}
+
 func TestPercent(t *testing.T) {
 	assert.Equal(t, "100%", Percent(100))
 	assert.Equal(t, "0%", Percent(0))


### PR DESCRIPTION
Fixes Issue - #170 
- Add Ch(value float64) function for character units (ch)
- Add Ex(value float64) function for x-height units (ex)
- Include comprehensive tests for both functions
- Follow existing patterns for float64 unit functions