### PR TITLE
feat: add Wbr element constructor

### DIFF
--- a/elements.go
+++ b/elements.go
@@ -38,6 +38,11 @@ func Br(attrs attrs.Props) *Element {
 	return newElement("br", attrs)
 }
 
+// Wbr creates a <wbr> element. <wbr> is a void element, so it never has children.
+func Wbr(attrs attrs.Props) *Element {
+	return newElement("wbr", attrs)
+}
+
 // Blockquote creates a <blockquote> element.
 func Blockquote(attrs attrs.Props, children ...Node) *Element {
 	return newElement("blockquote", attrs, children...)

--- a/elements_test.go
+++ b/elements_test.go
@@ -59,6 +59,12 @@ func TestBr(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+func TestWbr(t *testing.T) {
+	expected := `<wbr>`
+	el := Wbr(nil)
+	assert.Equal(t, expected, el.Render())
+}
+
 func TestCode(t *testing.T) {
 	expected := `<code>Code snippet</code>`
 	el := Code(nil, Text("Code snippet"))


### PR DESCRIPTION
Closes #156.

\`wbr\` was already listed in \`voidElements\` so the renderer knew not to emit a closing tag, but there was no \`Wbr(attrs)\` helper to actually construct one. Mirrored the existing \`Br\` constructor (sibling void element) and added a unit test alongside \`TestBr\`.