### PR TITLE
feat: add Track element constructor

### DIFF
--- a/elements.go
+++ b/elements.go
@@ -511,6 +511,11 @@ func Source(attrs attrs.Props, children ...Node) *Element {
 	return newElement("source", attrs, children...)
 }
 
+// Track creates a <track> element. <track> is a void element, so it never has children.
+func Track(attrs attrs.Props) *Element {
+	return newElement("track", attrs)
+}
+
 // ========== Image Map Elements ==========
 
 // Map creates a <map> element.

--- a/elements_test.go
+++ b/elements_test.go
@@ -696,6 +696,16 @@ func TestVideoWithSourceElementsAndFallbackText(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+func TestTrack(t *testing.T) {
+	expected := `<track kind="captions" src="captions.vtt" srclang="en">`
+	el := Track(attrs.Props{
+		attrs.Src: "captions.vtt",
+		"kind":    "captions",
+		"srclang": "en",
+	})
+	assert.Equal(t, expected, el.Render())
+}
+
 // ========== Image Map Elements ==========
 
 func TestMapAndArea(t *testing.T) {


### PR DESCRIPTION
Closes #155.

\`track\` was already in \`voidElements\` so the renderer wasn't emitting a closing tag, but there was no \`Track(attrs)\` helper to construct one. Mirrored the \`Source\` constructor (sibling media element). Test added alongside the video/source test.