### PR TITLE
feat: add Picture element constructor

### DIFF
--- a/elements.go
+++ b/elements.go
@@ -235,6 +235,12 @@ func Img(attrs attrs.Props) *Element {
 	return newElement("img", attrs)
 }
 
+// Picture creates a <picture> element. Typical usage wraps zero or more
+// <source> children and a final <img> fallback.
+func Picture(attrs attrs.Props, children ...Node) *Element {
+	return newElement("picture", attrs, children...)
+}
+
 // ========== Head Elements ==========
 
 // Base creates a <base> element.

--- a/elements_test.go
+++ b/elements_test.go
@@ -333,6 +333,15 @@ func TestImg(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+func TestPicture(t *testing.T) {
+	expected := `<picture><source media="(min-width:650px)" srcset="large.jpg"><img alt="A picture" src="small.jpg"></picture>`
+	el := Picture(nil,
+		Source(attrs.Props{"media": "(min-width:650px)", "srcset": "large.jpg"}),
+		Img(attrs.Props{attrs.Src: "small.jpg", attrs.Alt: "A picture"}),
+	)
+	assert.Equal(t, expected, el.Render())
+}
+
 // ========== Head Elements ==========
 
 func TestBase(t *testing.T) {


### PR DESCRIPTION
Closes #154.

\`picture\` is just a regular flow element wrapping zero or more \`source\` children plus an \`img\` fallback, so it goes through \`newElement\` with variadic children like the rest of the multimedia elements. Test covers the standard srcset use case.