### PR TITLE
feat: add Bdi and Bdo element constructors

### DIFF
--- a/elements.go
+++ b/elements.go
@@ -138,6 +138,18 @@ func B(attrs attrs.Props, children ...Node) *Element {
 	return newElement("b", attrs, children...)
 }
 
+// Bdi creates a <bdi> element, isolating a span of text whose directionality
+// may differ from the surrounding text.
+func Bdi(attrs attrs.Props, children ...Node) *Element {
+	return newElement("bdi", attrs, children...)
+}
+
+// Bdo creates a <bdo> element, overriding the current directionality of text
+// (its dir attribute is required for it to do anything useful).
+func Bdo(attrs attrs.Props, children ...Node) *Element {
+	return newElement("bdo", attrs, children...)
+}
+
 // U creates a <u> element.
 func U(attrs attrs.Props, children ...Node) *Element {
 	return newElement("u", attrs, children...)

--- a/elements_test.go
+++ b/elements_test.go
@@ -170,6 +170,18 @@ func TestB(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+func TestBdi(t *testing.T) {
+	expected := `<bdi>السلام عليكم</bdi>`
+	el := Bdi(nil, Text("السلام عليكم"))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestBdo(t *testing.T) {
+	expected := `<bdo dir="rtl">Reversed text</bdo>`
+	el := Bdo(attrs.Props{attrs.Dir: "rtl"}, Text("Reversed text"))
+	assert.Equal(t, expected, el.Render())
+}
+
 func TestU(t *testing.T) {
 	expected := `<u>Unarticulated text</u>`
 	el := U(nil, Text("Unarticulated text"))


### PR DESCRIPTION
For #157.

Two HTML5 directionality elements that were missing from \`elements.go\`. Both are regular flow elements with children, so just a couple of \`newElement\` wrappers next to the existing inline text elements. Tests added alongside \`TestB\`.