### PR TITLE
feat(attrs): add ClassNames helper for conditional class lists

### DIFF
--- a/attrs/utils.go
+++ b/attrs/utils.go
@@ -20,3 +20,29 @@ func Merge(attrMaps ...Props) Props {
 	}
 	return mergedAttrs
 }
+
+// ClassNames joins the non-empty class names with a single space. Empty strings
+// and strings consisting only of whitespace are skipped, which makes it easy
+// to mix conditional branches inline:
+//
+//	attrs.Class: attrs.ClassNames(
+//	    "btn",
+//	    elem.If(isPrimary, "btn-primary", ""),
+//	    elem.If(isDisabled, "btn-disabled", ""),
+//	)
+//
+// Each entry is also trimmed of surrounding whitespace.
+func ClassNames(classes ...string) string {
+	var b strings.Builder
+	for _, c := range classes {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(c)
+	}
+	return b.String()
+}

--- a/attrs/utils_test.go
+++ b/attrs/utils_test.go
@@ -33,3 +33,23 @@ func TestMerge(t *testing.T) {
 
 	assert.Equal(t, expectedMergedStyle, mergedStyle)
 }
+
+func TestClassNames(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"none", nil, ""},
+		{"single", []string{"btn"}, "btn"},
+		{"two", []string{"btn", "btn-primary"}, "btn btn-primary"},
+		{"skip empty", []string{"btn", "", "btn-primary"}, "btn btn-primary"},
+		{"trim whitespace", []string{"  btn  ", "\tbtn-primary\n"}, "btn btn-primary"},
+		{"skip whitespace-only", []string{"btn", "   ", "btn-primary"}, "btn btn-primary"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ClassNames(tc.in...))
+		})
+	}
+}


### PR DESCRIPTION
Closes #165.

Joins non-empty, trimmed class names with single spaces so callers can mix conditional branches inline without having to manage spacing:

```go
attrs.Class: attrs.ClassNames(
    "btn",
    elem.If(isPrimary, "btn-primary", ""),
    elem.If(isDisabled, "btn-disabled", ""),
)
```

Empty entries (including whitespace-only ones from a falsy \`If\` branch) are dropped, surrounding whitespace is trimmed. Table-driven test covers the empty / single / two / skip / trim cases.