### PR TITLE
Add CI benchmark regression check

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,55 @@
+# Runs the benchmarks for both the PR base and the PR head on the same
+# runner, then compares them with benchstat. Running both sides on one
+# machine cancels out most runner-to-runner performance variance, and
+# benchstat only reports deltas that are statistically significant.
+#
+# The comparison is informational (it never fails the build) because
+# shared CI runners are still noisy — treat a flagged regression as a
+# prompt to investigate, not an automatic verdict.
+
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Benchmark PR branch
+        run: go test -run='^$' -bench=. -benchmem -count=10 . | tee "$RUNNER_TEMP/head.txt"
+
+      - name: Benchmark base branch
+        run: |
+          git checkout --detach ${{ github.event.pull_request.base.sha }}
+          go test -run='^$' -bench=. -benchmem -count=10 . | tee "$RUNNER_TEMP/base.txt" || true
+
+      - name: Compare with benchstat
+        run: |
+          {
+            echo "## Benchmark comparison (base vs. PR)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if ! grep -q '^Benchmark' "$RUNNER_TEMP/base.txt"; then
+            echo "No benchmarks found on the base branch; nothing to compare." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          benchstat "$RUNNER_TEMP/base.txt" "$RUNNER_TEMP/head.txt" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test tidy
+.PHONY: test tidy bench
 
 tidy:
 	@echo "Tidying up module..."
@@ -7,3 +7,7 @@ tidy:
 test:
 	@echo "Running tests..."
 	go test ./...
+
+bench:
+	@echo "Running benchmarks..."
+	go test -run='^$$' -bench=. -benchmem .

--- a/elem_bench_test.go
+++ b/elem_bench_test.go
@@ -1,0 +1,110 @@
+package elem
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chasefleming/elem-go/attrs"
+	"github.com/chasefleming/elem-go/styles"
+)
+
+func BenchmarkRenderSimpleElement(b *testing.B) {
+	el := Div(attrs.Props{attrs.ID: "container", attrs.Class: "main"}, Text("Hello, World!"))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		el.Render()
+	}
+}
+
+func BenchmarkRenderManyAttributes(b *testing.B) {
+	el := Input(attrs.Props{
+		attrs.Type:         "text",
+		attrs.ID:           "username",
+		attrs.Name:         "username",
+		attrs.Class:        "form-control input-lg",
+		attrs.Placeholder:  "Enter your username",
+		attrs.Value:        "chase",
+		attrs.Required:     "true",
+		attrs.Autofocus:    "true",
+		attrs.Maxlength:    "64",
+		attrs.Autocomplete: "off",
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		el.Render()
+	}
+}
+
+func BenchmarkRenderLargeList(b *testing.B) {
+	items := make([]string, 1000)
+	for i := range items {
+		items[i] = fmt.Sprintf("Item %d", i)
+	}
+	list := Ul(attrs.Props{attrs.Class: "list"},
+		TransformEach(items, func(item string) Node {
+			return Li(attrs.Props{attrs.Class: "list-item"}, Text(item))
+		})...,
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		list.Render()
+	}
+}
+
+func BenchmarkRenderDeepNesting(b *testing.B) {
+	el := Span(nil, Text("leaf"))
+	for i := 0; i < 100; i++ {
+		el = Div(attrs.Props{attrs.Class: "level"}, el)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		el.Render()
+	}
+}
+
+func BenchmarkRenderTextEscaping(b *testing.B) {
+	el := P(nil, Text(`5 < 6 && 7 > 4, "quoted" & 'single' <script>alert("xss")</script>`))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		el.Render()
+	}
+}
+
+// BenchmarkBuildAndRenderPage measures constructing the element tree and
+// rendering it, mirroring the typical per-request usage pattern.
+func BenchmarkBuildAndRenderPage(b *testing.B) {
+	rows := make([]int, 50)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		page := Html(nil,
+			Head(nil,
+				Title(nil, Text("Dashboard")),
+				Meta(attrs.Props{attrs.Charset: "utf-8"}),
+			),
+			Body(attrs.Props{attrs.Style: styles.Props{
+				styles.Margin:     "0",
+				styles.FontFamily: "sans-serif",
+			}.ToInline()},
+				Header(attrs.Props{attrs.Class: "header"},
+					H1(nil, Text("Dashboard")),
+				),
+				Table(attrs.Props{attrs.Class: "data"},
+					TransformEach(rows, func(row int) Node {
+						return Tr(nil,
+							Td(nil, Text(fmt.Sprintf("Row %d", row))),
+							Td(nil, Text("value")),
+							Td(nil, Text("status")),
+						)
+					})...,
+				),
+			),
+		)
+		page.Render()
+	}
+}


### PR DESCRIPTION
Adds a CI workflow that runs the benchmarks for both the PR base and head on the same runner and reports a benchstat comparison in the job summary.