### PR TITLE
Stream text escaping and cut attribute-sort allocations

### DIFF
--- a/elem.go
+++ b/elem.go
@@ -2,7 +2,7 @@ package elem
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/chasefleming/elem-go/attrs"
@@ -92,7 +92,9 @@ func (n NoneNode) RenderWithOptions(opts RenderOptions) string {
 type TextNode string
 
 func (t TextNode) RenderTo(builder *strings.Builder, opts RenderOptions) {
-	builder.WriteString(EscapeNodeContents(string(t)))
+	// Stream the escaped text directly into the builder to avoid
+	// allocating an intermediate escaped string.
+	nodeContentReplacer.WriteString(builder, string(t))
 }
 
 func (t TextNode) Render() string {
@@ -203,17 +205,25 @@ func (e *Element) RenderTo(builder *strings.Builder, opts RenderOptions) {
 	switch len(e.Attrs) {
 	case 0:
 	case 1:
-		for k := range e.Attrs {
-			e.renderAttrTo(k, builder)
+		for k, v := range e.Attrs {
+			renderAttrTo(k, v, builder)
 		}
 	default:
-		keys := make([]string, 0, len(e.Attrs))
+		// Use a stack-allocated array for typical attribute counts so
+		// sorting the keys doesn't allocate.
+		var keysArr [16]string
+		var keys []string
+		if len(e.Attrs) <= len(keysArr) {
+			keys = keysArr[:0]
+		} else {
+			keys = make([]string, 0, len(e.Attrs))
+		}
 		for k := range e.Attrs {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
-			e.renderAttrTo(k, builder)
+			renderAttrTo(k, e.Attrs[k], builder)
 		}
 	}
 
@@ -242,17 +252,14 @@ func (e *Element) RenderTo(builder *strings.Builder, opts RenderOptions) {
 }
 
 // return string representation of given attribute with its value
-func (e *Element) renderAttrTo(attrName string, builder *strings.Builder) {
+func renderAttrTo(attrName, attrVal string, builder *strings.Builder) {
 	if _, exists := booleanAttrs[attrName]; exists {
 		// boolean attribute presents its name only if the value is "true"
-		if e.Attrs[attrName] == "true" {
+		if attrVal == "true" {
 			builder.WriteString(` `)
 			builder.WriteString(attrName)
 		}
 	} else {
-		// regular attribute has a name and a value
-		attrVal := e.Attrs[attrName]
-
 		// A necessary check to to avoid adding extra quotes around values that are already single-quoted
 		// An example is '{"quantity": 5}'
 		isSingleQuoted := strings.HasPrefix(attrVal, "'") && strings.HasSuffix(attrVal, "'")

--- a/elements_test.go
+++ b/elements_test.go
@@ -1,6 +1,7 @@
 package elem
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/chasefleming/elem-go/attrs"
@@ -74,6 +75,23 @@ func TestCode(t *testing.T) {
 func TestDiv(t *testing.T) {
 	expected := `<div class="container">Hello, Elem!</div>`
 	el := Div(attrs.Props{attrs.Class: "container"}, Text("Hello, Elem!"))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestDivWithManyAttributes(t *testing.T) {
+	// More than 16 attributes so rendering takes the heap-allocated
+	// key-sorting path rather than the stack-array fast path.
+	props := attrs.Props{}
+	expected := `<div`
+	for i := 1; i <= 20; i++ {
+		key := fmt.Sprintf("data-key-%02d", i)
+		value := fmt.Sprintf("value-%02d", i)
+		props[key] = value
+		expected += fmt.Sprintf(` %s="%s"`, key, value)
+	}
+	expected += `></div>`
+
+	el := Div(props)
 	assert.Equal(t, expected, el.Render())
 }
 


### PR DESCRIPTION
A second round of rendering optimizations. Escaped text is now written directly into the output builder instead of allocating an intermediate string, attribute keys are sorted in a stack-allocated array for elements with up to 16 attributes, and attribute values are passed through instead of being looked up in the map a second time.

Rendered output is byte-for-byte identical, the public API is unchanged, and the minimum Go version is unaffected. Adds a test covering elements with more than 16 attributes, a path the suite did not previously exercise.