### PR TITLE
Add remaining HTML5 elements for complete coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,15 @@ Additionally, `None` can be used to create an empty element, as in `elem.Div(nil
 
 - **Document Structure**: `Html`, `Head`, `Body`, `Title`, `Link`, `Meta`, `Style`, `Base`
 - **Text Content**: `H1`, `H2`, `H3`, `H4`, `H5`, `H6`, `P`, `Blockquote`, `Pre`, `Code`, `I`, `Br`, `Wbr`, `Hr`, `Small`, `Q`, `Cite`, `Abbr`, `Data`, `Time`, `Var`, `Samp`, `Kbd`
-- **Sectioning & Semantic Layout**: `Article`, `Aside`, `FigCaption`, `Figure`, `Footer`, `Header`, `Hgroup`, `Main`, `Mark`, `Nav`, `Section`
+- **Sectioning & Semantic Layout**: `Article`, `Aside`, `FigCaption`, `Figure`, `Footer`, `Header`, `Hgroup`, `Main`, `Mark`, `Nav`, `Search`, `Section`
 - **Form Elements**: `Form`, `Input`, `Textarea`, `Button`, `Select`, `Optgroup`, `Option`, `Label`, `Fieldset`, `Legend`, `Datalist`, `Meter`, `Output`, `Progress`
 - **Interactive Elements**: `Details`, `Dialog`, `Menu`, `Summary`
 - **Grouping Content**: `Div`, `Span`, `Li`, `Ul`, `Ol`, `Dl`, `Dt`, `Dd`
-- **Tables**: `Table`, `Tr`, `Td`, `Th`, `TBody`, `THead`, `TFoot`
+- **Tables**: `Table`, `Caption`, `Col`, `Colgroup`, `Tr`, `Td`, `Th`, `TBody`, `THead`, `TFoot`
 - **Hyperlinks and Multimedia**: `Img`, `Picture`, `Map`, `Area`
-- **Embedded Content**: `Audio`, `Iframe`, `Source`, `Track`, `Video`
-- **Script-supporting Elements**: `Script`, `Noscript`
-- **Inline Semantic**: `A`, `Strong`, `Em`, `Code`, `I`, `B`, `Bdi`, `Bdo`, `U`, `Sub`, `Sup`, `Ruby`, `Rt`, `Rp`
+- **Embedded Content**: `Audio`, `Canvas`, `Embed`, `Iframe`, `Object`, `Source`, `Track`, `Video`
+- **Script-supporting Elements**: `Script`, `Noscript`, `Slot`, `Template`
+- **Inline Semantic**: `A`, `Strong`, `Em`, `Code`, `I`, `B`, `Bdi`, `Bdo`, `U`, `S`, `Sub`, `Sup`, `Del`, `Dfn`, `Ins`, `Ruby`, `Rt`, `Rp`
 
 ### Raw HTML Insertion
 

--- a/attrs/attrs.go
+++ b/attrs/attrs.go
@@ -100,6 +100,7 @@ const (
 
 	// Miscellaneous Attributes
 
+	Data       = "data"  // Used for the <object> element's resource URL
 	DataPrefix = "data-" // Used for custom data attributes e.g., "data-custom"
 	Download   = "download"
 	Draggable  = "draggable"
@@ -110,6 +111,7 @@ const (
 
 	RowSpan = "rowspan"
 	ColSpan = "colspan"
+	Span    = "span"
 	Scope   = "scope"
 	Headers = "headers"
 

--- a/elements.go
+++ b/elements.go
@@ -332,6 +332,11 @@ func Section(attrs attrs.Props, children ...Node) *Element {
 	return newElement("section", attrs, children...)
 }
 
+// Search creates a <search> element.
+func Search(attrs attrs.Props, children ...Node) *Element {
+	return newElement("search", attrs, children...)
+}
+
 // Details creates a <details> element.
 func Details(attrs attrs.Props, children ...Node) *Element {
 	return newElement("details", attrs, children...)
@@ -393,6 +398,17 @@ func NoScript(attrs attrs.Props, children ...Node) *Element {
 	return newElement("noscript", attrs, children...)
 }
 
+// Slot creates a <slot> element.
+func Slot(attrs attrs.Props, children ...Node) *Element {
+	return newElement("slot", attrs, children...)
+}
+
+// Template creates a <template> element. Its children are rendered inline
+// like any other element; the library does not treat its contents specially.
+func Template(attrs attrs.Props, children ...Node) *Element {
+	return newElement("template", attrs, children...)
+}
+
 // --- Semantic Text Content Elements ---
 
 // Abbr creates an <abbr> element.
@@ -415,6 +431,17 @@ func Data(attrs attrs.Props, children ...Node) *Element {
 	return newElement("data", attrs, children...)
 }
 
+// Del creates a <del> element, representing text that has been deleted
+// from a document.
+func Del(attrs attrs.Props, children ...Node) *Element {
+	return newElement("del", attrs, children...)
+}
+
+// Dfn creates a <dfn> element.
+func Dfn(attrs attrs.Props, children ...Node) *Element {
+	return newElement("dfn", attrs, children...)
+}
+
 // FigCaption creates a <figcaption> element.
 func FigCaption(attrs attrs.Props, children ...Node) *Element {
 	return newElement("figcaption", attrs, children...)
@@ -423,6 +450,12 @@ func FigCaption(attrs attrs.Props, children ...Node) *Element {
 // Figure creates a <figure> element.
 func Figure(attrs attrs.Props, children ...Node) *Element {
 	return newElement("figure", attrs, children...)
+}
+
+// Ins creates an <ins> element, representing text that has been inserted
+// into a document.
+func Ins(attrs attrs.Props, children ...Node) *Element {
+	return newElement("ins", attrs, children...)
 }
 
 // Kbd creates a <kbd> element.
@@ -438,6 +471,12 @@ func Mark(attrs attrs.Props, children ...Node) *Element {
 // Q creates a <q> element.
 func Q(attrs attrs.Props, children ...Node) *Element {
 	return newElement("q", attrs, children...)
+}
+
+// S creates an <s> element, rendering text with a strikethrough for content
+// that is no longer accurate or relevant.
+func S(attrs attrs.Props, children ...Node) *Element {
+	return newElement("s", attrs, children...)
 }
 
 // Samp creates a <samp> element.
@@ -480,6 +519,22 @@ func Rp(attrs attrs.Props, children ...Node) *Element {
 // Table creates a <table> element.
 func Table(attrs attrs.Props, children ...Node) *Element {
 	return newElement("table", attrs, children...)
+}
+
+// Caption creates a <caption> element.
+func Caption(attrs attrs.Props, children ...Node) *Element {
+	return newElement("caption", attrs, children...)
+}
+
+// Colgroup creates a <colgroup> element. Per the HTML spec, it takes either
+// a span attribute or <col> children, but not both.
+func Colgroup(attrs attrs.Props, children ...Node) *Element {
+	return newElement("colgroup", attrs, children...)
+}
+
+// Col creates a <col> element. <col> is a void element, so it never has children.
+func Col(attrs attrs.Props) *Element {
+	return newElement("col", attrs)
 }
 
 // THead creates a <thead> element.
@@ -537,6 +592,21 @@ func Source(attrs attrs.Props, children ...Node) *Element {
 // Track creates a <track> element. <track> is a void element, so it never has children.
 func Track(attrs attrs.Props) *Element {
 	return newElement("track", attrs)
+}
+
+// Canvas creates a <canvas> element.
+func Canvas(attrs attrs.Props, children ...Node) *Element {
+	return newElement("canvas", attrs, children...)
+}
+
+// Embed creates an <embed> element. <embed> is a void element, so it never has children.
+func Embed(attrs attrs.Props) *Element {
+	return newElement("embed", attrs)
+}
+
+// Object creates an <object> element.
+func Object(attrs attrs.Props, children ...Node) *Element {
+	return newElement("object", attrs, children...)
 }
 
 // ========== Image Map Elements ==========

--- a/elements_test.go
+++ b/elements_test.go
@@ -219,7 +219,7 @@ func TestCdata(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestCdataEscaping (t *testing.T) {
+func TestCdataEscaping(t *testing.T) {
 	expected := `<![CDATA[Some CDATA content with ]]&gt; in it]]>`
 	actual := CdataNode("Some CDATA content with ]]> in it").Render()
 	assert.Equal(t, expected, actual)
@@ -475,6 +475,12 @@ func TestSection(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+func TestSearch(t *testing.T) {
+	expected := `<search><form action="/search"><input name="q" type="search"></form></search>`
+	el := Search(nil, Form(attrs.Props{attrs.Action: "/search"}, Input(attrs.Props{attrs.Type: "search", attrs.Name: "q"})))
+	assert.Equal(t, expected, el.Render())
+}
+
 func TestHgroup(t *testing.T) {
 	expected := `<hgroup><h1>Frankenstein</h1><p>Or: The Modern Prometheus</p></hgroup>`
 	el := Hgroup(nil, H1(nil, Text("Frankenstein")), P(nil, Text("Or: The Modern Prometheus")))
@@ -541,6 +547,18 @@ func TestNoScript(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+func TestSlot(t *testing.T) {
+	expected := `<slot name="header">Default header</slot>`
+	el := Slot(attrs.Props{attrs.Name: "header"}, Text("Default header"))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestTemplate(t *testing.T) {
+	expected := `<template id="row-template"><p>Row content</p></template>`
+	el := Template(attrs.Props{attrs.ID: "row-template"}, P(nil, Text("Row content")))
+	assert.Equal(t, expected, el.Render())
+}
+
 // --- Semantic Text Content Elements ---
 
 func TestAbbr(t *testing.T) {
@@ -585,6 +603,18 @@ func TestData(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+func TestDel(t *testing.T) {
+	expected := `<del cite="edits.html" datetime="2024-01-01T00:00:00Z">removed text</del>`
+	el := Del(attrs.Props{attrs.Cite: "edits.html", attrs.Datetime: "2024-01-01T00:00:00Z"}, Text("removed text"))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestDfn(t *testing.T) {
+	expected := `<p><dfn>HTML</dfn> is the standard markup language for web pages.</p>`
+	el := P(nil, Dfn(nil, Text("HTML")), Text(" is the standard markup language for web pages."))
+	assert.Equal(t, expected, el.Render())
+}
+
 func TestFigCaption(t *testing.T) {
 	expected := `<figcaption>Description of the figure.</figcaption>`
 	el := FigCaption(nil, Text("Description of the figure."))
@@ -594,6 +624,12 @@ func TestFigCaption(t *testing.T) {
 func TestFigure(t *testing.T) {
 	expected := `<figure><img alt="An image" src="image.jpg"><figcaption>An image</figcaption></figure>`
 	el := Figure(nil, Img(attrs.Props{attrs.Src: "image.jpg", attrs.Alt: "An image"}), FigCaption(nil, Text("An image")))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestIns(t *testing.T) {
+	expected := `<ins cite="edits.html" datetime="2024-01-01T00:00:00Z">inserted text</ins>`
+	el := Ins(attrs.Props{attrs.Cite: "edits.html", attrs.Datetime: "2024-01-01T00:00:00Z"}, Text("inserted text"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -612,6 +648,12 @@ func TestMark(t *testing.T) {
 func TestQ(t *testing.T) {
 	expected := `<p>The W3C's mission is <q cite="https://www.w3.org/Consortium/">To lead the World Wide Web to its full potential</q>.</p>`
 	el := P(nil, Text("The W3C's mission is "), Q(attrs.Props{attrs.Cite: "https://www.w3.org/Consortium/"}, Text("To lead the World Wide Web to its full potential")), Text("."))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestS(t *testing.T) {
+	expected := `<p><s>Was $50</s> Now $25!</p>`
+	el := P(nil, S(nil, Text("Was $50")), Text(" Now $25!"))
 	assert.Equal(t, expected, el.Render())
 }
 
@@ -707,6 +749,24 @@ func TestTable(t *testing.T) {
 	assert.Equal(t, expected, el.Render())
 }
 
+func TestCaption(t *testing.T) {
+	expected := `<table><caption>Monthly savings</caption><tr><td>January</td></tr></table>`
+	el := Table(nil, Caption(nil, Text("Monthly savings")), Tr(nil, Td(nil, Text("January"))))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestColgroup(t *testing.T) {
+	expected := `<colgroup span="2"></colgroup>`
+	el := Colgroup(attrs.Props{attrs.Span: "2"})
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestCol(t *testing.T) {
+	expected := `<colgroup><col span="2"><col></colgroup>`
+	el := Colgroup(nil, Col(attrs.Props{attrs.Span: "2"}), Col(nil))
+	assert.Equal(t, expected, el.Render())
+}
+
 // ========== Embedded Content ==========
 
 func TestEmbedLink(t *testing.T) {
@@ -748,6 +808,30 @@ func TestTrack(t *testing.T) {
 		"kind":    "captions",
 		"srclang": "en",
 	})
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestCanvas(t *testing.T) {
+	expected := `<canvas height="200" id="chart" width="300">Your browser does not support the canvas tag.</canvas>`
+	el := Canvas(attrs.Props{attrs.ID: "chart", attrs.Width: "300", attrs.Height: "200"}, Text("Your browser does not support the canvas tag."))
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestEmbed(t *testing.T) {
+	expected := `<embed height="200" src="video.mp4" type="video/mp4" width="300">`
+	el := Embed(attrs.Props{attrs.Src: "video.mp4", attrs.Type: "video/mp4", attrs.Width: "300", attrs.Height: "200"})
+	assert.Equal(t, expected, el.Render())
+}
+
+func TestObject(t *testing.T) {
+	expected := `<object data="document.pdf" height="200" name="doc" type="application/pdf" width="300">Fallback content</object>`
+	el := Object(attrs.Props{
+		attrs.Data:   "document.pdf",
+		attrs.Type:   "application/pdf",
+		attrs.Name:   "doc",
+		attrs.Width:  "300",
+		attrs.Height: "200",
+	}, Text("Fallback content"))
 	assert.Equal(t, expected, el.Render())
 }
 


### PR DESCRIPTION
Closes #157

Adds the 13 remaining elements from the HTML5 coverage meta-issue: `canvas`, `caption`, `col`, `colgroup`, `del`, `dfn`, `embed`, `ins`, `object`, `s`, `search`, `slot`, and `template`.

## Changes

- **`elements.go`**: 13 new constructors following the existing patterns, placed in their matching sections. `Col` and `Embed` use the void element pattern (no children param, like `Wbr`/`Track`); both tags were already registered in the `voidElements` map so they render correctly with no rendering changes.
- **`attrs/attrs.go`**: adds `Span = "span"` (for `<col>`/`<colgroup>`) and `Data = "data"` (for `<object>`). All other element-specific attributes (`cite`, `datetime`, `type`, `name`, `src`, `width`, `height`) already existed.
- **`elements_test.go`**: a test per element mirroring the existing style, exercising the element-specific attributes (e.g. `TestDel` uses `cite` + `datetime`, `TestCol` confirms void rendering inside a `<colgroup>`, `TestEmbed` confirms void rendering with `src`/`type`).
- **`README.md`**: all 13 added to their categories in the Supported Elements list.

## Notes

- `marquee` (also on the issue's list) is intentionally omitted: it's obsolete in the WHATWG spec ("entirely obsolete, and must not be used by authors"). Anyone who truly needs one can use `elem.Raw`.
- Doc comments call out the spec quirks that the library (by design) doesn't enforce: `Colgroup` takes either a `span` attribute or `<col>` children but not both, and `Template` children render inline rather than modeling the spec's separate template-contents fragment.
- With this, every element from #157 is either implemented (`bdi`, `bdo`, `picture`, `track`, `wbr` were done previously) or intentionally skipped, completing the meta-issue.